### PR TITLE
Dev jwtsource examples (#40)

### DIFF
--- a/bundle/jwtbundle/src/set.c
+++ b/bundle/jwtbundle/src/set.c
@@ -160,6 +160,19 @@ jwtbundle_Bundle *jwtbundle_Set_GetJWTBundleForTrustDomain(
     return bundle;
 }
 
+jwtbundle_Set *jwtbundle_Set_Clone(jwtbundle_Set *set)
+{
+    jwtbundle_Set *ret = jwtbundle_NewSet(0);
+    mtx_lock(&(set->mtx));
+    for(size_t i = 0, size = hmlenu(set->bundles); i < size; ++i) {
+        jwtbundle_Bundle *bundle
+            = jwtbundle_Bundle_Clone(set->bundles[i].value);
+        jwtbundle_Set_Add(ret, bundle);
+    }
+    mtx_unlock(&(set->mtx));
+    return ret;
+}
+
 void jwtbundle_Set_Free(jwtbundle_Set *s)
 {
     if(s) {

--- a/bundle/jwtbundle/src/set.h
+++ b/bundle/jwtbundle/src/set.h
@@ -49,6 +49,15 @@ void jwtbundle_Set_Add(jwtbundle_Set *s, jwtbundle_Bundle *bundle);
 void jwtbundle_Set_Remove(jwtbundle_Set *s, const spiffeid_TrustDomain td);
 
 /**
+ * Copies the content of a bundle set.
+ *
+ * \param set [in] JWT Bundle Set object pointer.
+ * \returns a copy of the set. Must be freed using jwtbundle_Set_Free
+ * function.
+ */
+jwtbundle_Set *jwtbundle_Set_Clone(jwtbundle_Set *set);
+
+/**
  * Checks if a bundle belongs to the set.
  *
  * \param set [in] Set of JWT bundles object pointer.

--- a/bundle/jwtbundle/tests/check_bundle.c
+++ b/bundle/jwtbundle/tests/check_bundle.c
@@ -966,7 +966,7 @@ START_TEST(test_jwtbundle_Bundle_Print_Errors)
     ck_assert_int_eq(err, ERROR1);
 
     // NULL BIO* error
-    bundle_ptr = 1; //"valid" bundle
+    bundle_ptr = (jwtbundle_Bundle*) 1; //"valid" bundle
     err = jwtbundle_Bundle_print_BIO(bundle_ptr, offset, out);
     ck_assert_int_eq(err, ERROR2);
 }

--- a/bundle/jwtbundle/tests/check_set.c
+++ b/bundle/jwtbundle/tests/check_set.c
@@ -363,8 +363,8 @@ START_TEST(test_jwtbundle_Set_Print_Errors)
     ck_assert_int_eq(err, ERROR1);
 
     // NULL BIO* error
-    set = 1; //"valid" set
-    err = jwtbundle_Bundle_print_BIO(set, offset, out);
+    set =(jwtbundle_Set*) 1; //"valid" set
+    err = jwtbundle_Set_print_BIO(set, offset, out);
     ck_assert_int_eq(err, ERROR2);
 }
 END_TEST

--- a/workload/CMakeLists.txt
+++ b/workload/CMakeLists.txt
@@ -179,3 +179,9 @@ set(C_CLIENT_VALIDATE
 )
 add_executable(c_client_validate "${C_CLIENT_VALIDATE}")
 target_link_libraries(c_client_validate client)
+
+set(JWTSOURCE_EXAMPLE
+    src/jwtsource_example.c
+)
+add_executable(jwtsource_example "${JWTSOURCE_EXAMPLE}")
+target_link_libraries(jwtsource_example source)

--- a/workload/src/jwtsource.c
+++ b/workload/src/jwtsource.c
@@ -98,7 +98,7 @@ void workloadapi_JWTSource_applyJWTBundle_Set(workloadapi_JWTSource *source,
 {
     mtx_lock(&(source->mtx));
     jwtbundle_Set_Free(source->bundles);
-    source->bundles = set;
+    source->bundles = jwtbundle_Set_Clone(set);
     mtx_unlock(&(source->mtx));
 }
 

--- a/workload/src/jwtsource_example.c
+++ b/workload/src/jwtsource_example.c
@@ -1,0 +1,118 @@
+#include "jwtsource.h"
+#include <threads.h>
+#include <time.h>
+
+int print_forever(void *args)
+{
+    workloadapi_JWTSource *source = (workloadapi_JWTSource *) args;
+    err_t err = NO_ERROR;
+
+    while(!workloadapi_JWTSource_checkClosed(source)) {
+        spiffeid_ID id = { NULL, NULL };
+        string_t audience = string_new("example.org");
+        string_arr_t extra = NULL;
+        string_t audience2 = string_new("example2.org");
+        arrput(extra, audience2);
+        string_t audience3 = string_new("example3.org");
+        arrput(extra, audience3);
+        jwtsvid_Params params = { .audience = audience,
+                                  .extra_audiences = extra,
+                                  .subject = id };
+        jwtsvid_SVID *svid
+            = workloadapi_JWTSource_GetJWTSVID(source, &params, &err);
+
+        util_string_t_Free(audience);
+        util_string_t_Free(audience2);
+        util_string_t_Free(audience3);
+
+        if(svid) {
+            printf("SVID: %s%s\n", svid->id.td.name, svid->id.path);
+            printf(" Path: %s\n", svid->id.path);
+            printf(" Trust Domain: %s\n", svid->id.td.name);
+            printf(" Token: %s\n", svid->token);
+            printf(" Expiry:%s", ctime(&svid->expiry));
+            printf(" Claims: [\n");
+
+            for(size_t j = 0, size = shlenu(svid->claims); j < size; ++j) {
+                char *value
+                    = json_dumps(svid->claims[j].value, JSON_ENCODE_ANY);
+                printf("  '%s':'%s'\n", svid->claims[j].key, value);
+                free(value);
+            }
+            printf(" ]\n");
+            jwtbundle_Set_Print(source->bundles);
+            jwtbundle_Source *src = jwtbundle_SourceFromSet(
+                jwtbundle_Set_Clone(source->bundles));
+            jwtsvid_SVID *svid2 = jwtsvid_ParseAndValidate(
+                svid->token, src, svid->audience, &err);
+
+            if(svid2) {
+                printf("  Validated SVID: \n");
+                printf("   SVID Path: %s\n", svid2->id.path);
+                printf("   Trust Domain: %s\n", svid2->id.td.name);
+                printf("   Token: %s\n", svid2->token);
+                printf("   Expiry:%s", ctime(&svid->expiry));
+                printf("   Claims: [\n");
+                for(size_t j = 0, size = shlenu(svid2->claims); j < size;
+                    ++j) {
+                    char *value
+                        = json_dumps(svid2->claims[j].value, JSON_ENCODE_ANY);
+                    printf("    key: %s, value: %s\n", svid2->claims[j].key,
+                           value);
+                    free(value);
+                }
+                printf("   ]\n");
+                jwtsvid_SVID_Free(svid2);
+            } else {
+                printf("  COULDN'T VALIDATE SVID!\n");
+            }
+
+            jwtsvid_SVID_Free(svid);
+            jwtbundle_Source_Free(src);
+            printf("\n\n\nPress ENTER to stop.\n\n\n");
+            struct timespec tp = { 5, 0 }; // 5 seconds
+            thrd_sleep(&tp, NULL);
+        } else {
+            printf(" COULDN'T FETCH SVID!\n");
+        }
+    }
+    return 0;
+}
+
+int main()
+{
+    err_t err = NO_ERROR;
+    workloadapi_JWTSource *source = workloadapi_NewJWTSource(NULL, &err);
+
+    if(err) {
+        printf("ERROR %d\n", err);
+        return err;
+    }
+    printf("\n\n\nPress ENTER to stop.\n\n\n");
+
+    err = workloadapi_JWTSource_Start(source);
+
+    if(err) {
+        printf("ERROR %d\n", err);
+        return err;
+    }
+
+    thrd_t thread;
+    thrd_create(&thread, print_forever, source);
+
+    char ch;
+    scanf("%c", &ch);
+
+    printf("Stopping.\n");
+
+    err = workloadapi_JWTSource_Close(source);
+
+    if(err != 1) { // error 1 == client closed properly
+        printf("ERROR %d\n", err);
+        return err;
+    }
+
+    thrd_join(thread, NULL);
+    workloadapi_JWTSource_Free(source);
+    return 0;
+}

--- a/workload/tests/check_jwtsource.c
+++ b/workload/tests/check_jwtsource.c
@@ -61,11 +61,13 @@ START_TEST(test_workloadapi_JWTSource_applyJWTBundle_Set);
     err_t err;
     workloadapi_JWTSource *tested = workloadapi_NewJWTSource(NULL, &err);
 
-    jwtbundle_Set *set = (jwtbundle_Set *) 1;
-
+    jwtbundle_Set *set = jwtbundle_NewSet(0);
+    jwtbundle_Bundle* bundle = jwtbundle_New(spiffeid_TrustDomainFromString("spiffe://example.com",&err));
+    jwtbundle_Set_Add(set,bundle);
     workloadapi_JWTSource_applyJWTBundle_Set(tested, set);
 
-    ck_assert_ptr_eq(tested->bundles, (jwtbundle_Set *) 1);
+    ck_assert_ptr_ne(tested->bundles,set);
+    ck_assert_str_eq(tested->bundles->bundles[0].value->td.name,set->bundles[0].value->td.name);
 
     tested->bundles = NULL;
     workloadapi_JWTSource_Free(tested);


### PR DESCRIPTION
* feat: added jwtsource.[h.c]

* tests: added check_jwtsource.c

* feat: changed jwtsource_getJWTSVID to take parameters.

* fix: uses_config now allocates/frees config

* feat: add jwtsource.c to workload/CMakeLists.txt

* tests: add jwtsource tests to tests/CMakeLists.txt

* fix: getXXXBundleforTD now returns ERROR2 on
no bundle found for TD

* test: new GetJWTSVID and GetJWTBundle(...) tests.

* test: ported x509source test from jwtsource tests

* feat: added jwtsource example

* feat: added jwtsource example to CMakeLists.txt

* feat: added jwtbundle_Set_Clone

* feat: applyJWTBundle_Set now clones the set

* feat: fixed example, needs key printing fix

* feat: added jwtsource.[h.c]

* tests: added check_jwtsource.c

* feat: changed jwtsource_getJWTSVID to take parameters.

* fix: uses_config now allocates/frees config

* feat: add jwtsource.c to workload/CMakeLists.txt

* tests: add jwtsource tests to tests/CMakeLists.txt

* fix: getXXXBundleforTD now returns ERROR2 on
no bundle found for TD

* test: new GetJWTSVID and GetJWTBundle(...) tests.

* test: ported x509source test from jwtsource tests

* feat: added jwtsource example

* feat: added jwtsource example to CMakeLists.txt

* feat: added jwtbundle_Set_Clone

* feat: applyJWTBundle_Set now clones the set

* feat: fixed example, needs key printing fix

* feat: added support for EC keys

Co-authored-by: otaviolcs3 <olas@cin.ufpe.br>
(cherry picked from commit 4cdba412370654f2d58a765c555c173b799b3394)

* bug: printing pkey crashes. see comments for info.

* fix: re-enabled bundle print, minor restructuring

* fix: fix tests wrt set_clone

* feat: improve error handling

* fix: success on close error 1

* style: fix style on set.c

* fix: fix test_jwtbundle_Set_Print_Errors to use Set function

* fix: using new print function and free'd strings

* fix: added casting warned by compiler